### PR TITLE
Add FAQ section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5164,6 +5164,11 @@
         "repeat-string": "^1.5.4"
       }
     },
+    "details-polyfill": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/details-polyfill/-/details-polyfill-1.1.0.tgz",
+      "integrity": "sha512-YARtvrZ+FobZBMjfAyCxNZ5Cm5riB2tKMsdUQvTFnCvg3OeAkOGCoSxgDZT0uAXV+t5zgJYMGWd/ftVI6v8I0w=="
+    },
     "detect-indent": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "author": "Austin Green",
   "dependencies": {
     "bootstrap": "^4.3.1",
+    "details-polyfill": "^1.1.0",
     "gatsby": "^2.13.31",
     "gatsby-image": "^2.0.23",
     "gatsby-plugin-netlify": "^2.0.6",

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -5,9 +5,8 @@ import "../styles/index.scss";
 import useSiteMetadata from "./SiteMetadata";
 import { withPrefix } from "gatsby";
 
-let $;
 if (typeof window !== `undefined`) {
-  $ = require("jquery");
+  require("jquery");
   require("bootstrap/js/dist/alert");
 }
 

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,0 +1,183 @@
+import React from "react";
+
+const FAQ = () => (
+  <section className="faq">
+    <div className="container-fluid distribute-rows">
+      <div className="row">
+        <div className="col">
+          <div className="text-center">
+            <h1 className="display-title">FAQ</h1>
+          </div>
+        </div>
+      </div>
+      <div className="row">
+        <div className="col">
+          <div className="collapsable-list">
+            <details className="collapsable-list__item">
+              <summary className="summary">Why full debt cancellation?</summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                Doesn’t full cancellation mostly beneﬁt higher income people?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                What impact will cancelling student debt have on the economy?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                OK, but how do we pay for it?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                Does Congress Have to Approve Debt Relief?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                What’s the problem with targeted relief?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                Isn’t debt cancellation unfair to people who have already paid
+                back all of their student loans?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">What is education for?</summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+            <details className="collapsable-list__item">
+              <summary className="summary">
+                What kind of beneﬁts can debt cancellation have for society and
+                the economy?
+              </summary>
+              <p className="content">
+                Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                Vestibulum hendrerit, erat id feugiat lobortis, enim nulla
+                pretium ex, eu auctor lacus eros in tortor. Sed justo metus,
+                sodales et lobortis id, sodales at nulla. In sed iaculis dui.
+                Mauris rhoncus convallis augue in volutpat. Aliquam sodales
+                tellus nec neque pretium, at auctor felis condimentum. Maecenas
+                placerat vestibulum tortor, nec consectetur nulla laoreet id.
+                Pellentesque vel velit pulvinar, blandit ex nec, tempus diam.
+                Phasellus dui massa, tincidunt et dictum vel, consequat sed
+                nisi. Mauris dapibus nunc sed neque molestie imperdiet. In
+                aliquam rhoncus metus eget ornare.
+              </p>
+            </details>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+);
+
+export default FAQ;

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import "details-polyfill";
 
 const FAQ = () => (
   <section className="faq">

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -1,5 +1,8 @@
 import React from "react";
-import "details-polyfill";
+
+if (typeof window !== `undefined`) {
+  require("details-polyfill");
+}
 
 const FAQ = () => (
   <section className="faq">

--- a/src/sections/FAQ/index.js
+++ b/src/sections/FAQ/index.js
@@ -66,9 +66,7 @@ const FAQ = () => (
               </p>
             </details>
             <details className="collapsable-list__item">
-              <summary className="summary">
-                OK, but how do we pay for it?
-              </summary>
+              <summary className="summary">How do we pay for it?</summary>
               <p className="content">
                 Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                 Vestibulum hendrerit, erat id feugiat lobortis, enim nulla

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -61,3 +61,30 @@ details {
     border-top: none;
   }
 }
+
+/*
+  styles improvements related to https://github.com/rstacruz/details-polyfill
+*/
+html.no-details details > summary {
+  list-style: none;
+}
+
+html.no-details details > summary::before {
+  content: '' !important;
+  height: 0;
+  width: 0;
+}
+
+html.no-details details > summary::before {
+  border-color: transparent transparent transparent $primary;
+  border-style: solid;
+  border-width: .4em 0 .4em .8em;
+  position: relative;
+  top: 0;
+  transform: rotate(0deg);
+}
+
+html.no-details details[open] > summary::before {
+  top: .4em;
+  transform: rotate(90deg);
+}

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -43,4 +43,16 @@ details {
     padding-left: 1.5rem;
     margin-top: $spacer * 1.5;
   }
+
+  /*
+    IE doesn't support details as other modern browsers so we remove the boder
+    in order to let the text being shown without bad applied customizations
+  */
+  @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+    border-top: none;
+  }
+
+  @supports (-ms-ime-align: auto) {
+    border-top: none;
+  }
 }

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -22,7 +22,12 @@
 
 details {
   border-top: 0.125rem solid $black;
-  padding: 1.5rem 2rem 2.25rem;
+  padding: 1.5rem 0 2.25rem;
+
+  @include media-breakpoint-up(sm) {
+    padding-right: 2rem;
+    padding-left: 2rem;
+  }
 
   summary {
     font-weight: $font-weight-bold;

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -26,9 +26,15 @@ details {
 
   summary {
     font-weight: $font-weight-bold;
+    outline: none;
   }
 
-  & > summary::-webkit-details-marker {
+  // pseudo elements are defined separately check https://bit.ly/2U0pJKb
+  summary::marker {
+    color: $primary;
+  }
+
+  summary::-webkit-details-marker {
     color: $primary;
   }
 
@@ -38,4 +44,3 @@ details {
     margin-top: $spacer * 1.5;
   }
 }
-

--- a/src/sections/FAQ/style.scss
+++ b/src/sections/FAQ/style.scss
@@ -1,0 +1,41 @@
+.faq {
+  background: $white;
+
+  .display-title {
+    margin-bottom: $spacer * 3;
+
+    @include media-breakpoint-up(xl) {
+      margin-bottom: $spacer * 5;
+    }
+  }
+
+  .distribute-rows {
+    justify-content: flex-start;
+  }
+}
+
+.collapsable-list {
+  margin: 0 auto;
+  max-width: 50rem;
+  width: 100%;
+}
+
+details {
+  border-top: 0.125rem solid $black;
+  padding: 1.5rem 2rem 2.25rem;
+
+  summary {
+    font-weight: $font-weight-bold;
+  }
+
+  & > summary::-webkit-details-marker {
+    color: $primary;
+  }
+
+  .content {
+    font-size: 1.125rem;
+    padding-left: 1.5rem;
+    margin-top: $spacer * 1.5;
+  }
+}
+

--- a/src/sections/Notification/style.scss
+++ b/src/sections/Notification/style.scss
@@ -13,6 +13,7 @@
   right: $grid-gutter-width / 2;
   width: 28.75rem;
   max-width: 100%;
+  z-index: $zindex-fixed;
 
   @include media-breakpoint-down(xs) {
     flex-direction: column;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -19,6 +19,9 @@ $font-size-base:              1.5rem;
 $headings-margin-bottom:      0;
 $paragraph-margin-bottom:     0;
 
+// Avoid the need of removing margins
+$headings-margin-bottom:      0;
+
 // Grid needs to be set in px
 $grid-gutter-width:           40px;
 
@@ -62,3 +65,4 @@ $btn-padding-x:               2.8rem;
 @import "../sections/Informative/style";
 @import "../sections/Join/style";
 @import "../sections/Notification/style";
+@import "../sections/FAQ/style";

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -13,6 +13,7 @@ import bgFist from "./img/image_3.png";
 import bgHandshake from "./img/image_1.png";
 import bgNewspaper from "./img/image_2.png";
 import Notification from "../sections/Notification";
+import FAQ from "../sections/FAQ";
 
 export const IndexPageTemplate = ({ display1, display2, items }) => (
   <>
@@ -57,6 +58,7 @@ export const IndexPageTemplate = ({ display1, display2, items }) => (
         elit. Ut consequat sapien a rhoncus convallis.
       </p>
     </Notification>
+    <FAQ />
   </>
 );
 


### PR DESCRIPTION
**What:**
Add a new section of FAQ

**Why:**
Closes https://github.com/debtcollective/student-debt-campaign/issues/8

**How:**
Add a new section of FAQ using [`<details>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/details) tag.

**Notice:** as previous created section I haven't add the CMS connection with the content. On top of that **this PR needs https://github.com/debtcollective/student-debt-campaign-netlify/pull/4** in order the FAQ render as show in the screenshots below.

Ultimately, I have choose to not add any extra polyfill for the details tag since the IE browsers difference will be that the user is not able to toggle the information but it is still usable, while people with more widely user browsers will have a enhance experience

**Notice:** This PR also add a fix within the notification component to bring it up.

## Screenshots
![http://recordit.co/evKJJeiNiR](http://recordit.co/evKJJeiNiR.gif)

[iPad](https://user-images.githubusercontent.com/1425162/63636568-53244200-c671-11e9-94f5-8bbffe3b2b34.png)
[IE Edge](https://user-images.githubusercontent.com/1425162/63636583-8070f000-c671-11e9-825a-f44159c47720.png)
[FireFox](https://user-images.githubusercontent.com/1425162/63636587-88c92b00-c671-11e9-8003-2495d4069b5a.png)
[Android Chrome](https://user-images.githubusercontent.com/1425162/63636589-8e267580-c671-11e9-8b11-694f5610c752.png)
