### PR TITLE
feat(notification): add notification banner

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gatsby-source-filesystem": "^2.0.26",
     "gatsby-transformer-remark": "^2.6.9",
     "gatsby-transformer-sharp": "^2.1.9",
+    "jquery": "^3.4.1",
     "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",
     "netlify-cms-app": "^2.9.6",

--- a/src/components/IconWrap/index.js
+++ b/src/components/IconWrap/index.js
@@ -2,7 +2,7 @@ import React from "react";
 
 const IconWrap = ({ src, ...rest }) => (
   <div className="icon-wrap" {...rest}>
-    <img src={src} />
+    <img src={src} alt="icon" />
   </div>
 );
 

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,7 +4,12 @@ import Footer from "../components/Footer";
 import "../styles/index.scss";
 import useSiteMetadata from "./SiteMetadata";
 import { withPrefix } from "gatsby";
-import "bootstrap/js/dist/alert";
+
+let $;
+if (typeof window !== `undefined`) {
+  $ = require("jquery");
+  require("bootstrap/js/dist/alert");
+}
 
 const TemplateWrapper = ({ children }) => {
   const { title, description } = useSiteMetadata();

--- a/src/components/Layout.js
+++ b/src/components/Layout.js
@@ -4,6 +4,7 @@ import Footer from "../components/Footer";
 import "../styles/index.scss";
 import useSiteMetadata from "./SiteMetadata";
 import { withPrefix } from "gatsby";
+import "bootstrap/js/dist/alert";
 
 const TemplateWrapper = ({ children }) => {
   const { title, description } = useSiteMetadata();

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -42,7 +42,7 @@ const Join = ({ image, background, count, title, colour, children }) => (
               <ul className="our-voices__list">
                 <li className="our-voices__list-item">
                   <div className="our-voices__img">
-                    <img src={user1} />
+                    <img src={user1} alt="user profile picture" />
                   </div>
                   <p className="our-voices__content">
                     <strong>@username</strong> Lorem ipsum dolor sit amet,
@@ -53,7 +53,7 @@ const Join = ({ image, background, count, title, colour, children }) => (
                 </li>
                 <li className="our-voices__list-item">
                   <div className="our-voices__img">
-                    <img src={user2} />
+                    <img src={user2} alt="user profile picture" />
                   </div>
                   <p className="our-voices__content">
                     <strong>@username</strong> Lorem ipsum dolor sit amet,
@@ -64,7 +64,7 @@ const Join = ({ image, background, count, title, colour, children }) => (
                 </li>
                 <li className="our-voices__list-item">
                   <div className="our-voices__img">
-                    <img src={user3} />
+                    <img src={user3} alt="user profile picture" />
                   </div>
                   <p className="our-voices__content">
                     <strong>@username</strong> Lorem ipsum dolor sit amet,
@@ -75,7 +75,7 @@ const Join = ({ image, background, count, title, colour, children }) => (
                 </li>
                 <li className="our-voices__list-item">
                   <div className="our-voices__img">
-                    <img src={user4} />
+                    <img src={user4} alt="user profile picture" />
                   </div>
                   <p className="our-voices__content">
                     <strong>@username</strong> Lorem ipsum dolor sit amet,

--- a/src/sections/Notification/index.js
+++ b/src/sections/Notification/index.js
@@ -1,0 +1,20 @@
+import React from "react";
+
+const Notification = ({ title, children }) => (
+  <div className="notification alert" role="alert">
+    <div className="notification-col">
+      <div className="notification__title">{title}</div>
+      <div className="notification__date">
+        Updated Wed, Nov 30, 2019 at 12:00 PM
+      </div>
+    </div>
+    <div className="notification-col">
+      <div className="notification__content">{children}</div>
+    </div>
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+);
+
+export default Notification;

--- a/src/sections/Notification/style.scss
+++ b/src/sections/Notification/style.scss
@@ -1,0 +1,66 @@
+.notification {
+  align-items: center;
+  background: $white;
+  border-radius: 0.250rem;
+  border: 0.125rem solid $black;
+  bottom: $grid-gutter-width / 2;
+  box-shadow: 0 0.875rem 1.75rem rgba(0,0,0,0.25), 0 0.625rem 0.625rem rgba(0,0,0,0.22);
+  display: flex;
+  flex-direction: row;
+  height: 11rem;
+  padding: 1.5rem;
+  position: fixed;
+  right: $grid-gutter-width / 2;
+  width: 28.75rem;
+  max-width: 100%;
+
+  @include media-breakpoint-down(xs) {
+    flex-direction: column;
+    height: auto;
+    width: calc(100% - #{$grid-gutter-width});
+  }
+
+  .close {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+  }
+
+  &-col {
+    align-items: center;
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    justify-content: space-around;
+    text-align: center;
+
+    @include media-breakpoint-down(xs) {
+      margin-top: $spacer;
+    }
+  }
+
+  &__content {
+    font-size: $font-size-base * 0.55;
+    text-align: left;
+    margin-left: $spacer * 1.5;
+
+    @include media-breakpoint-down(xs) {
+      margin-left: 0;
+    }
+  }
+
+  &__title {
+    @extend .text-monospace;
+    font-size: $font-size-base * 1.5;
+    line-height: 0.85;
+
+    @include media-breakpoint-down(xs) {
+      margin-bottom: $spacer * 0.5;
+    }
+  }
+
+  &__date {
+    color: #808080;
+    font-size: $font-size-base * 0.375;
+  }
+}

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -48,6 +48,7 @@ $btn-padding-x:               2.8rem;
 @import "node_modules/bootstrap/scss/type";
 @import "node_modules/bootstrap/scss/utilities";
 @import "node_modules/bootstrap/scss/buttons";
+@import "node_modules/bootstrap/scss/close";
 
 // run custom code after bootstrap loaded
 @import "./functions";
@@ -60,3 +61,4 @@ $btn-padding-x:               2.8rem;
 @import "../sections/Hero/style";
 @import "../sections/Informative/style";
 @import "../sections/Join/style";
+@import "../sections/Notification/style";

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -12,6 +12,7 @@ import newspaper from "./img/newspaper.png";
 import bgFist from "./img/image_3.png";
 import bgHandshake from "./img/image_1.png";
 import bgNewspaper from "./img/image_2.png";
+import Notification from "../sections/Notification";
 
 export const IndexPageTemplate = ({ display1, display2, items }) => (
   <>
@@ -50,6 +51,12 @@ export const IndexPageTemplate = ({ display1, display2, items }) => (
       We do not have student loans, but we are standing in solidarity with all
       those people who are on strike
     </Join>
+    <Notification title="We are winning">
+      <p>
+        <strong>NEW</strong> Lorem ipsum dolor sit amet, consectetur adipiscing
+        elit. Ut consequat sapien a rhoncus convallis.
+      </p>
+    </Notification>
   </>
 );
 


### PR DESCRIPTION
**What:**
Add the notification banner with fixed content

**Why:**
Closes https://github.com/debtcollective/student-debt-campaign/issues/11

**How:**
- Add a new sort of section to be used whenever a notification needs to be rendered

**Notice:** as previous created section I haven't add the CMS connection with the content. On top of that **this PR needs https://github.com/debtcollective/student-debt-campaign-netlify/pull/4** in order this section render as show in the screenshots below.

## Screenshots
![https://recordit.co/NbYmRTez5u](https://recordit.co/NbYmRTez5u.gif)