### PR TITLE
feat(cms): allow to render properly rich text

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "jquery": "^3.4.1",
     "lodash": "^4.17.15",
     "lodash-webpack-plugin": "^0.11.4",
+    "markdown-to-jsx": "^6.10.3",
     "netlify-cms-app": "^2.9.6",
     "netlify-cms-media-library-cloudinary": "^1.3.2",
     "netlify-cms-media-library-uploadcare": "^0.5.2",

--- a/src/sections/Informative/index.js
+++ b/src/sections/Informative/index.js
@@ -1,7 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Markdown from "markdown-to-jsx";
 
-const Informative = ({ title, content, remark }) => (
+const Informative = ({ title, children, remark }) => (
   <section className="informative">
     <div className="container-fluid distribute-rows justify-content-center extra-pad">
       <div className="row">
@@ -9,7 +10,9 @@ const Informative = ({ title, content, remark }) => (
           <div className="text-center">
             <h1 className="informative__title">{title}</h1>
           </div>
-          <p className="informative__content">{content}</p>
+          <div className="informative__content">
+            <Markdown>{children}</Markdown>
+          </div>
           <p className="informative__content">
             <strong>{remark}</strong>
           </p>
@@ -21,7 +24,7 @@ const Informative = ({ title, content, remark }) => (
 
 Informative.propTypes = {
   title: PropTypes.string,
-  content: PropTypes.string,
+  children: PropTypes.any,
   remark: PropTypes.string
 };
 

--- a/src/sections/Join/index.js
+++ b/src/sections/Join/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
+import Markdown from "markdown-to-jsx";
 
 const formatNumber = number =>
   number.toString().replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
@@ -34,7 +35,7 @@ const Join = ({
               </h2>
             </header>
             <div className="join__content">
-              {children}
+              <Markdown>{children}</Markdown>
               <p className="mt-4">
                 <strong>{remark}</strong>
               </p>

--- a/src/sections/Notification/index.js
+++ b/src/sections/Notification/index.js
@@ -1,4 +1,5 @@
 import React from "react";
+import Markdown from "markdown-to-jsx";
 import PropTypes from "prop-types";
 
 const Notification = ({ title, children, date }) => (
@@ -8,10 +9,9 @@ const Notification = ({ title, children, date }) => (
       <div className="notification__date">Updated {date}</div>
     </div>
     <div className="notification-col">
-      <div
-        className="notification__content"
-        dangerouslySetInnerHTML={{ __html: children }}
-      />
+      <div className="notification__content">
+        <Markdown>{children}</Markdown>
+      </div>
     </div>
     <button
       type="button"

--- a/src/templates/index-page.js
+++ b/src/templates/index-page.js
@@ -21,11 +21,9 @@ export const IndexPageTemplate = ({
 }) => (
   <>
     <Hero title={hero.title} actions={hero.actions} social={social} />
-    <Informative
-      title={demand.title}
-      content={demand.content}
-      remark={demand.remark}
-    />
+    <Informative title={demand.title} remark={demand.remark}>
+      {demand.content}
+    </Informative>
     {join_campaign.map(
       (
         { background, image, title, colour, content, count, remark, feed },

--- a/yarn.lock
+++ b/yarn.lock
@@ -9102,6 +9102,14 @@ markdown-table@^1.1.0:
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.3.tgz#9fcb69bcfdb8717bfd0398c6ec2d93036ef8de60"
   integrity sha512-1RUZVgQlpJSPWYbFSpmudq5nHY1doEIv89gBtF0s4gW1GF2XorxcA/70M5vq7rLv0a6mhOUccRsqkwhwLCIQ2Q==
 
+markdown-to-jsx@^6.10.3:
+  version "6.10.3"
+  resolved "https://registry.yarnpkg.com/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz#7f0946684acd321125ff2de7fd258a9b9c7c40b7"
+  integrity sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==
+  dependencies:
+    prop-types "^15.6.2"
+    unquote "^1.1.0"
+
 md5-file@^3.1.1:
   version "3.2.3"
   resolved "https://registry.yarnpkg.com/md5-file/-/md5-file-3.2.3.tgz#f9bceb941eca2214a4c0727f5e700314e770f06f"
@@ -14839,7 +14847,7 @@ unpipe@1.0.0, unpipe@~1.0.0:
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
   integrity sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=
 
-unquote@~1.1.1:
+unquote@^1.1.0, unquote@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/unquote/-/unquote-1.1.1.tgz#8fded7324ec6e88a0ff8b905e7c098cdc086d544"
   integrity sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=


### PR DESCRIPTION
**What:**
Allow to render text introduced with rich text widget properly within our site

**Why:**
Avoid the miss usage of rich text widgets

**How:**
Add markdown-to-jsx https://bundlephobia.com/result?p=markdown-to-jsx@6.10.3

## Screenshots
**Before:**
![image](https://user-images.githubusercontent.com/1425162/65504459-522c3d80-dec7-11e9-9632-e2376f18a480.png)

**After:**
![image](https://user-images.githubusercontent.com/1425162/65504465-58221e80-dec7-11e9-8497-f915370abf2e.png)
